### PR TITLE
HTML mode content changes now trigger change callbacks.

### DIFF
--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -1462,7 +1462,25 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
     [self callDelegateEditorTextDidChange];
 }
 
-#pragma mark - UITextField delegate
+#pragma mark - UITextViewDelegate
+
+- (BOOL)textViewShouldBeginEditing:(UITextField *)textField
+{
+    return YES;
+}
+
+- (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text
+{
+    [self callDelegateEditorTitleDidChange];
+    return YES;
+}
+
+- (BOOL)textViewShouldEndEditing:(UITextView *)textView
+{
+    return YES;
+}
+
+#pragma mark - UITextFieldDelegate
 
 - (BOOL)textFieldShouldBeginEditing:(UITextField *)textField
 {


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/437).

I could only test this in the demo app, and not integrated into WPiOS due to [this PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/2943) not being approved yet.

I'd suggest to not merge this code until we can properly test the integration, but I'm still posting the PR for code review & testing in the demo app.

/cc @bummytime 