### PR TITLE
HTML mode should now trigger all the appropriate events.

### DIFF
--- a/Classes/WPEditorView.h
+++ b/Classes/WPEditorView.h
@@ -143,6 +143,22 @@ stylesForCurrentSelection:(NSArray*)styles;
  */
 - (void)redo;
 
+#pragma mark - Text Access
+
+/**
+ *  @brief      Retrieves the content in both HTML and visual mode.
+ *
+ *  @returns    The content.
+ */
+- (NSString*)contents;
+
+/**
+ *  @brief      Retrieves the title in both HTML and visual mode.
+ *
+ *  @returns    The title.
+ */
+- (NSString*)title;
+
 #pragma mark - Selection
 
 

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -1497,10 +1497,9 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
     return YES;
 }
 
-- (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text
+- (void)textViewDidChange:(UITextView *)textView
 {
     [self callDelegateEditorTitleDidChange];
-    return YES;
 }
 
 - (BOOL)textViewShouldEndEditing:(UITextView *)textView
@@ -1517,8 +1516,9 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
 
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string
 {
+    textField.text = [textField.text stringByReplacingCharactersInRange:range withString:string];
     [self callDelegateEditorTitleDidChange];
-    return YES;
+    return NO;
 }
 
 - (BOOL)textFieldShouldReturn:(UITextField *)textField

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -995,6 +995,34 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
     [self callDelegateEditorTextDidChange];
 }
 
+#pragma mark - Text Access
+
+- (NSString*)contents
+{
+    NSString* contents = nil;
+    
+    if ([self isInVisualMode]) {
+        contents = [self.contentField html];
+    } else {
+        contents =  self.sourceView.text;
+    }
+    
+    return contents;
+}
+
+- (NSString*)title
+{
+    NSString* title = nil;
+    
+    if ([self isInVisualMode]) {
+        title = [self.titleField strippedHtml];
+    } else {
+        title =  self.sourceViewTitleField.text;
+    }
+    
+    return title;
+}
+
 #pragma mark - Scrolling support
 
 /**

--- a/Classes/WPEditorViewController.m
+++ b/Classes/WPEditorViewController.m
@@ -947,8 +947,8 @@ NSInteger const WPLinkAlertViewTag = 92;
 #pragma mark - Getters and Setters
 
 - (NSString*)titleText
-{
-    return [self.editorView.titleField strippedHtml];
+{    
+    return [self.editorView title];
 }
 
 - (void)setTitleText:(NSString*)titleText
@@ -970,7 +970,7 @@ NSInteger const WPLinkAlertViewTag = 92;
 
 - (NSString*)bodyText
 {
-    return [self.editorView.contentField html];
+    return [self.editorView contents];
 }
 
 - (void)setBodyText:(NSString*)bodyText


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/437).

Can be tested in WPiOS in branch `issue/editor-460-html-mode-editing`.

/cc @bummytime 