### PR TITLE
Fixes cursor under virtual keyboard.

### DIFF
--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -544,6 +544,7 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
          }
      } onComplete:^() {
          
+         [self refreshVisibleViewportAndContentSize];
          [self scrollToCaretAnimated:NO];
      }];
 }

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -544,6 +544,13 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
          }
      } onComplete:^() {
          
+         // WORKAROUND: it seems that without this call, typing doesn't always follow the caret
+         // position.
+         //
+         // HOW TO TEST THIS: disable the following line, and run the demo... type in the contents
+         // field while also showing the virtual keyboard.  You'll notice the caret can, at times,
+         // go behind the virtual keyboard.
+         //
          [self refreshVisibleViewportAndContentSize];
          [self scrollToCaretAnimated:NO];
      }];


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/465).
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/301).

/cc @bummytime 