### PR TITLE
Adjusted the source view's left/right insets on iPads

### DIFF
--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -16,9 +16,12 @@ static NSString* const kDefaultCallbackParameterComponentSeparator = @"=";
 static NSString* const kWPEditorViewFieldTitleId = @"zss_field_title";
 static NSString* const kWPEditorViewFieldContentId = @"zss_field_content";
 
-static const CGFloat HTMLViewLeftRightInset = 10.0f;
 static const CGFloat UITextFieldLeftRightInset = 15.5f;
+static const CGFloat iPadUITextFieldLeftRightInset = 90.0f;
 static const CGFloat UITextFieldFieldHeight = 44.0f;
+static const CGFloat HTMLViewTopInset = 15.0f;
+static const CGFloat HTMLViewLeftRightInset = 10.0f;
+static const CGFloat iPadHTMLViewLeftRightInset = 85.0f;
 
 static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
 
@@ -106,10 +109,16 @@ static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
 
 - (void)createSourceTitleViewWithFrame:(CGRect)frame
 {
-    NSAssert(!_sourceViewTitleField, @"The source view title field must not exist when this method is called!");
-	
-    CGFloat textWidth = CGRectGetWidth(frame) - (2 * UITextFieldLeftRightInset);
-    _sourceViewTitleField = [[UITextField alloc] initWithFrame:CGRectMake(UITextFieldLeftRightInset, 5.0f, textWidth, UITextFieldFieldHeight)];
+    NSAssert(!_sourceViewTitleField, @"The source view title field must not exist when this method is called!");	
+    
+    if (IS_IPAD) {
+        CGFloat textWidth = CGRectGetWidth(frame) - (2 * iPadUITextFieldLeftRightInset);
+        _sourceViewTitleField = [[UITextField alloc] initWithFrame:CGRectMake(iPadUITextFieldLeftRightInset, 5.0f, textWidth, UITextFieldFieldHeight)];
+    } else {
+        CGFloat textWidth = CGRectGetWidth(frame) - (2 * UITextFieldLeftRightInset);
+        _sourceViewTitleField = [[UITextField alloc] initWithFrame:CGRectMake(UITextFieldLeftRightInset, 5.0f, textWidth, UITextFieldFieldHeight)];
+    }
+    
     _sourceViewTitleField.hidden = YES;
     _sourceViewTitleField.font = [WPFontManager merriweatherBoldFontOfSize:18.0f];
     _sourceViewTitleField.autocapitalizationType = UITextAutocapitalizationTypeWords;
@@ -125,8 +134,13 @@ static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
 {
     NSAssert(!_sourceContentDividerView, @"The source divider view must not exist when this method is called!");
     
-    CGFloat lineWidth = CGRectGetWidth(frame) - (2 * UITextFieldLeftRightInset);
-    _sourceContentDividerView = [[UIView alloc] initWithFrame:CGRectMake(UITextFieldLeftRightInset, CGRectGetMaxY(frame), lineWidth, CGRectGetHeight(frame))];
+    if (IS_IPAD) {
+        CGFloat lineWidth = CGRectGetWidth(frame) - (2 * iPadUITextFieldLeftRightInset);
+        _sourceContentDividerView = [[UIView alloc] initWithFrame:CGRectMake(iPadUITextFieldLeftRightInset, CGRectGetMaxY(frame), lineWidth, CGRectGetHeight(frame))];
+    } else {
+        CGFloat lineWidth = CGRectGetWidth(frame) - (2 * UITextFieldLeftRightInset);
+        _sourceContentDividerView = [[UIView alloc] initWithFrame:CGRectMake(UITextFieldLeftRightInset, CGRectGetMaxY(frame), lineWidth, CGRectGetHeight(frame))];
+    }
     _sourceContentDividerView.backgroundColor = [WPStyleGuide readGrey];
     _sourceContentDividerView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     _sourceContentDividerView.hidden = YES;
@@ -143,7 +157,11 @@ static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
     _sourceView.autocorrectionType = UITextAutocorrectionTypeNo;
     _sourceView.autoresizingMask =  UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     _sourceView.autoresizesSubviews = YES;
-    _sourceView.textContainerInset = UIEdgeInsetsMake(15.0f, HTMLViewLeftRightInset, 0.0f, HTMLViewLeftRightInset);
+    if (IS_IPAD) {
+        _sourceView.textContainerInset = UIEdgeInsetsMake(HTMLViewTopInset, iPadHTMLViewLeftRightInset, 0, iPadHTMLViewLeftRightInset);
+    } else {
+        _sourceView.textContainerInset = UIEdgeInsetsMake(HTMLViewTopInset, HTMLViewLeftRightInset, 0.0f, HTMLViewLeftRightInset);
+    }
     _sourceView.delegate = self;
     [self addSubview:_sourceView];
 }


### PR DESCRIPTION
Title has it. Final fix for https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/65

![screen shot 2015-01-16 at 10 51 08 am](https://cloud.githubusercontent.com/assets/154014/5780121/a5ac2d12-9d6d-11e4-9d90-f9077398f2d6.png)
![screen shot 2015-01-16 at 10 51 21 am](https://cloud.githubusercontent.com/assets/154014/5780124/a7f11d62-9d6d-11e4-878f-2039a7b34aff.png)

/cc @SergioEstevao 