### PR TITLE
Adjusts spacing on iPhone 6 format bar

### DIFF
--- a/Classes/WPDeviceIdentification.h
+++ b/Classes/WPDeviceIdentification.h
@@ -16,4 +16,11 @@
  */
 + (BOOL)isIPhoneSixPlus;
 
+/**
+ *  @brief      Call this method to know if the current device is an iPhone6.
+ *
+ *  @returns    YES if the device is an iPhone6.  NO otherwise.
+ */
++ (BOOL)isIPhoneSix;
+
 @end

--- a/Classes/WPDeviceIdentification.m
+++ b/Classes/WPDeviceIdentification.m
@@ -4,7 +4,14 @@
 
 + (BOOL)isIPhoneSixPlus
 {
-    return IS_IPHONE && ([[UIScreen mainScreen] respondsToSelector:@selector(nativeScale)] && [[UIScreen mainScreen] nativeScale] > 2.5f);
+    return IS_IPHONE && ([[UIScreen mainScreen] respondsToSelector:@selector(nativeScale)]
+                     && [[UIScreen mainScreen] nativeScale] > 2.5f);
+}
+
++ (BOOL)isIPhoneSix
+{
+    return ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone &&
+            MAX([UIScreen mainScreen].bounds.size.height,[UIScreen mainScreen].bounds.size.width) == 667);
 }
 
 @end

--- a/Classes/WPEditorToolbarView.m
+++ b/Classes/WPEditorToolbarView.m
@@ -7,6 +7,7 @@ static int kDefaultToolbarItemPadding = 10;
 static int kDefaultToolbarLeftPadding = 10;
 
 static int kNegativeToolbarItemPadding = 12;
+static int kNegativeSixToolbarItemPadding = 6;
 static int kNegativeSixPlusToolbarItemPadding = 2;
 static int kNegativeLeftToolbarLeftPadding = 3;
 static int kNegativeRightToolbarPadding = 20;
@@ -89,6 +90,8 @@ static const CGFloat WPEditorToolbarDividerLineWidth = 0.6f;
     
     if ([WPDeviceIdentification isIPhoneSixPlus]) {
         toolbarItemsSeparation = kNegativeSixPlusToolbarItemPadding;
+    } else if ([WPDeviceIdentification isIPhoneSix]) {
+        toolbarItemsSeparation = kNegativeSixToolbarItemPadding;
     } else {
         toolbarItemsSeparation = kNegativeToolbarItemPadding;
     }


### PR DESCRIPTION
Fixes #488. iPhone 6 format bar spacing adjust to make it more even.

**iPhone 4:**
![scaled screen shot 2015-01-22 at 6 00 48 pm](https://cloud.githubusercontent.com/assets/154014/5867399/33866f88-a261-11e4-9b4c-20fbe3481f3f.png)

**iPhone 6:**
![scaled screen shot 2015-01-22 at 6 01 38 pm](https://cloud.githubusercontent.com/assets/154014/5867400/3716dc14-a261-11e4-8a4e-0c1d3a771011.png)

**iPhone 6 Plus:**
![scaled screen shot 2015-01-22 at 6 02 13 pm](https://cloud.githubusercontent.com/assets/154014/5867401/38cf877c-a261-11e4-97f4-cd63096d24e4.png)

/cc @diegoreymendez 