### PR TITLE
Tapping list format bar buttons now creates new list on new/empty posts

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -1556,8 +1556,10 @@ ZSSField.prototype.emptyFieldIfNoContents = function() {
     if (text.length == 0) {
         
         var hasChildImages = (this.wrappedObject.find('img').length > 0);
+        var hasUnorderedList = (this.wrappedObject.find('ul').length > 0);
+        var hasOrderedList = (this.wrappedObject.find('ol').length > 0);
         
-        if (!hasChildImages) {
+        if (!hasChildImages && !hasUnorderedList && !hasOrderedList) {
             this.wrappedObject.empty();
         }
     }


### PR DESCRIPTION
Fixes #367. 

Created a separate issue (#506) to address the missing ```p``` tag after adding a new list when the content body is empty. (This was already an existing issue with images.)

@diegoreymendez or @aerych would you mind taking a quick peek...very simple PR.