### PR TITLE
Issue/514 blank editor

### DIFF
--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -1187,7 +1187,6 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
     [self.webView stringByEvaluatingJavaScriptFromString:trigger];
     
     [self workaroundiOS7FocusIssueAfterHidingBehindAnotherVC];
-    [self refreshVisibleViewportAndContentSize];
 }
 
 - (void)insertImage:(NSString *)url alt:(NSString *)alt

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -271,14 +271,13 @@ static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
         if ([keyPath isEqualToString:WPEditorViewWebViewContentSizeKey]) {
             NSValue *newValue = change[NSKeyValueChangeNewKey];
             
-            CGSize newSize;
-            [newValue getValue:&newSize];
+            CGSize newSize = [newValue CGSizeValue];
         
             if (newSize.height != self.lastEditorHeight) {
                 
                 // First make sure that the content size is not changed without us recalculating it.
                 //
-                self.webView.scrollView.contentSize = CGSizeMake(self.frame.size.width, self.lastEditorHeight);
+                self.webView.scrollView.contentSize = CGSizeMake(CGRectGetWidth(self.frame), self.lastEditorHeight);
                 [self workaroundBrokenWebViewRendererBug];
                 
                 // Then recalculate it asynchronously so the UIWebView doesn't break.
@@ -380,7 +379,7 @@ static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
     
     if (keyboardOrigin.y > 0) {
         
-        CGFloat vOffset = self.frame.size.height - keyboardOrigin.y;
+        CGFloat vOffset = CGRectGetHeight(self.frame) - keyboardOrigin.y;
         
         UIEdgeInsets insets = UIEdgeInsetsMake(0.0f, 0.0f, vOffset, 0.0f);
         
@@ -419,7 +418,7 @@ static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
     NSInteger newHeight = [newHeightString integerValue];
     
     self.lastEditorHeight = newHeight;
-    self.webView.scrollView.contentSize = CGSizeMake(self.frame.size.width, newHeight);
+    self.webView.scrollView.contentSize = CGSizeMake(CGRectGetWidth(self.frame), newHeight);
 }
 
 #pragma mark - UIWebViewDelegate
@@ -1101,7 +1100,7 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
     CGFloat offsetBottom = caretYOffset + lineHeight;
     
     BOOL mustScroll = (caretYOffset < viewport.origin.y
-                       || offsetBottom > viewport.origin.y + viewport.size.height);
+                       || offsetBottom > viewport.origin.y + CGRectGetHeight(viewport));
     
     if (mustScroll) {
         // DRM: by reducing the necessary height we avoid an issue that moves the caret out
@@ -1116,7 +1115,7 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
         
         CGRect targetRect = CGRectMake(0.0f,
                                        caretYOffset,
-                                       viewport.size.width,
+                                       CGRectGetWidth(viewport),
                                        necessaryHeight);
         
         [self.webView.scrollView scrollRectToVisible:targetRect animated:animated];

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -358,6 +358,7 @@ static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
 
 - (void)keyboardDidShow:(NSNotification *)notification
 {
+    [self refreshVisibleViewportAndContentSize];
     [self scrollToCaretAnimated:NO];
 }
 

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -275,7 +275,7 @@ static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
             [newValue getValue:&newSize];
         
             if (newSize.height != self.lastEditorHeight) {
-                [self refreshVisibleViewportAndContentSize];
+                self.webView.scrollView.contentSize = CGSizeMake(self.frame.size.width, self.lastEditorHeight);
                 [self workaroundBrokenWebViewRendererBug];
             }
         }


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/514).

This fix tries not to stray too far from what we already have, in order to make sure we can deliver a working editor in v4.8.  However if this fix is shown to cause trouble, please let me know and I'll try other options.

/cc @aerych