### PR TITLE
Use a different way to capture Y position when range reports incorrect p...

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -297,8 +297,8 @@ ZSSEditor.getYCaretInfo = function() {
     var y = 0;
     var height = 0;
     var selection = window.getSelection();
-    
-    if (! selection.rangeCount) { // if no selection available just return CaretPositionUnknow
+    var noSelectionAvailable = selection.rangeCount == 0;
+    if (noSelectionAvailable) {
         this.caretInfo.y = CaretPositionUnknow;
         this.caretInfo.height = CaretPositionUnknow;
         return this.caretInfo;
@@ -310,7 +310,7 @@ ZSSEditor.getYCaretInfo = function() {
     // PROBLEM: iOS seems to have problems getting the offset for some empty nodes and return
     // 0 (zero) as the selection range top offset.
     //
-    // WORKAROUND: To fix this problem we just get the node's offset instead.
+    // WORKAROUND: To fix this problem we use a different method to obtain the Y position instead.
     //
     if (needsToWorkAroundNewlineBug) {
         var closerParentNode = ZSSEditor.closerParentNode();

--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -274,15 +274,21 @@ ZSSEditor.getJoinedCaretArguments = function() {
 };
 
 ZSSEditor.getCaretYPosition = function() {
-    var sel = window.getSelection();
-    // Next line is comented to prevent deselecting selection. It looks like work but if there are any issues will appear then uconmment it as well as code above.
-    //sel.collapseToStart();
-    var range = sel.getRangeAt(0);
-    var span = document.createElement('span');// something happening here preventing selection of elements
+    var selection = window.getSelection();
+    var range = selection.getRangeAt(0);
+    var span = document.createElement("span");
+    // Ensure span has dimensions and position by
+    // adding a zero-width space character
+    span.appendChild( document.createTextNode("\u200b") );
     range.insertNode(span);
-    var topPosition = span.offsetTop;
-    span.parentNode.removeChild(span);
-    return topPosition;
+    var y = span.offsetTop;
+    var spanParent = span.parentNode;
+    spanParent.removeChild(span);
+    
+    // Glue any broken text nodes back together
+    spanParent.normalize();
+    
+    return y;
 }
 
 ZSSEditor.getYCaretInfo = function() {

--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -13,6 +13,8 @@ var isUsingiOS = true;
 // THe default callback parameter separator
 var defaultCallbackSeparator = '~';
 
+var CaretPositionUnknow = -9999;
+
 // The editor object
 var ZSSEditor = {};
 
@@ -296,9 +298,9 @@ ZSSEditor.getYCaretInfo = function() {
     var height = 0;
     var selection = window.getSelection();
     
-    if (! selection.rangeCount) { // if no selection available just return 0
-        this.caretInfo.y = y;
-        this.caretInfo.height = height;
+    if (! selection.rangeCount) { // if no selection available just return CaretPositionUnknow
+        this.caretInfo.y = CaretPositionUnknow;
+        this.caretInfo.height = CaretPositionUnknow;
         return this.caretInfo;
     }
     

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -26,6 +26,8 @@ static const CGFloat iPadHTMLViewLeftRightInset = 85.0f;
 
 static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
 
+static NSInteger CaretPositionUnknow = -9999;
+
 @interface WPEditorView () <UITextViewDelegate, UIWebViewDelegate, UITextFieldDelegate>
 
 #pragma mark - Cached caret & line data
@@ -1085,16 +1087,17 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
 #pragma mark - Scrolling support
 
 /**
- *  @brief      Scrolls to a position where the caret is visible.
- *
- *  @param      offset      The offset to show.
- *  @param      height      The height to show below the specified offset.  If this exceeds the
- *                          scroll content size, a smaller height will be automatically used.
+ *  @brief      Scrolls to a position where the caret is visible. This uses the values stored in caretYOffest and lineHeight properties.
+ *  @discussion If the values of both properties  match CaretPositionUnknow no scrolling happens.
+ *  @param      animated    If the scrolling shoud be animated  The offset to show.
  */
 - (void)scrollToCaretAnimated:(BOOL)animated
 {
+    if (self.caretYOffset == CaretPositionUnknow
+        && self.lineHeight == CaretPositionUnknow) {
+        return;
+    }
     CGRect viewport = [self viewport];
-    
     CGFloat caretYOffset = self.caretYOffset;
     CGFloat lineHeight = self.lineHeight;
     CGFloat offsetBottom = caretYOffset + lineHeight;

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -1184,8 +1184,6 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
 {
     NSString *trigger = [NSString stringWithFormat:@"ZSSEditor.insertLocalImage(\"%@\", \"%@\");", uniqueId, url];
     [self.webView stringByEvaluatingJavaScriptFromString:trigger];
-    
-    [self workaroundiOS7FocusIssueAfterHidingBehindAnotherVC];
 }
 
 - (void)insertImage:(NSString *)url alt:(NSString *)alt

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -1165,22 +1165,6 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
     [self callDelegateEditorTextDidChange];
 }
 
-#pragma mark - Exceptional Workarounds
-
-/**
- *  @brief      Fixes an issue in iOS 7 that prevents the editor view from properly recovering focus
- *              after the owning VC comes back from hiding behind another VC.
- */
-- (void)workaroundiOS7FocusIssueAfterHidingBehindAnotherVC
-{
-    if (NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_7_1) {
-        [self saveSelection];
-        [self.contentField blur];
-        [self.contentField focus];
-        [self restoreSelection];
-    }
-}
-
 #pragma mark - Images
 
 - (void)insertLocalImage:(NSString*)url uniqueId:(NSString*)uniqueId

--- a/Example/EditorDemo/WPViewController.m
+++ b/Example/EditorDemo/WPViewController.m
@@ -153,8 +153,10 @@ typedef NS_ENUM(NSUInteger,  WPViewControllerActionSheet) {
         NSString * imageID = [[NSUUID UUID] UUIDString];
         NSString * path = [NSString stringWithFormat:@"%@/%@", NSTemporaryDirectory(), imageID];
         [data writeToFile:path atomically:YES];
-        [self.editorView insertLocalImage:[[NSURL fileURLWithPath:path] absoluteString] uniqueId:imageID];
-            
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.editorView insertLocalImage:[[NSURL fileURLWithPath:path] absoluteString] uniqueId:imageID];
+        });
+                    
         NSProgress * progress = [[NSProgress alloc] initWithParent:nil userInfo:@{@"imageID":imageID, @"url":path}];
         progress.cancellable = YES;
         progress.totalUnitCount = 100;


### PR DESCRIPTION
Fix #525

Uses an updated from [ZSSRichTextEditor](https://github.com/nnhubbard/ZSSRichTextEditor/blob/master/ZSSRichTextEditor/ZSSRichTextEditor.js#L138)  to find the correct position of the caret.

/cc @diegoreymendez 