### PR TITLE
Removed addition of space in ZSSEditor.removeCaptionFormatting

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -1208,7 +1208,7 @@ ZSSEditor.removeCaptionFormatting = function( html ) {
     // call methods to restore any transformed content from its visual presentation to its source code.
     var regex = /<label class="wp-temp" data-wp-temp="caption"[^>]*>([\s\S]+?)<\/label>/g;
 
-    var str = html.replace( regex, ZSSEditor.removeCaptionFormattingCallback ) + " "; // Add a trailing space for nice formatting.
+    var str = html.replace( regex, ZSSEditor.removeCaptionFormattingCallback );
 
     return str;
 }


### PR DESCRIPTION
Fixes #515 

This fix will restore the placeholder color functionality and fix the ```ZSSField.prototype.isEmpty()``` function (which has been broken for a little while now...it always returned false).

/cc @diegoreymendez and @aerych 
