### PR TITLE
Fixes a problem when the keyboard is shown under iOS 7.

### DIFF
--- a/Classes/WPDeviceIdentification.h
+++ b/Classes/WPDeviceIdentification.h
@@ -23,4 +23,11 @@
  */
 + (BOOL)isIPhoneSix;
 
+/**
+ *  @brief      Call this method to know if the current device is running iOS version older than 8.
+ *
+ *  @returns    YES if the device is running iOS version older than 8.  NO otherwise.
+ */
++ (BOOL)isiOSVersionEarlierThan8;
+
 @end

--- a/Classes/WPDeviceIdentification.m
+++ b/Classes/WPDeviceIdentification.m
@@ -14,4 +14,9 @@
             MAX([UIScreen mainScreen].bounds.size.height,[UIScreen mainScreen].bounds.size.width) == 667);
 }
 
++ (BOOL)isiOSVersionEarlierThan8
+{
+    return [[[UIDevice currentDevice] systemVersion] floatValue] < 8.0;
+}
+
 @end

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -5,6 +5,7 @@
 #import "WPEditorField.h"
 #import "WPImageMeta.h"
 #import "ZSSTextView.h"
+#import "WPDeviceIdentification.h"
 #import <WordPress-iOS-Shared/WPFontManager.h>
 #import <WordPress-iOS-Shared/WPStyleGuide.h>
 
@@ -368,9 +369,9 @@ static NSInteger CaretPositionUnknow = -9999;
 
 - (void)keyboardDidShow:(NSNotification *)notification
 {
-    BOOL isiOS7OrEarlier = ([[[UIDevice currentDevice] systemVersion] floatValue] < 8.0);
+    BOOL isiOSVersionEarlierThan8 = [WPDeviceIdentification isiOSVersionEarlierThan8];
     
-    if (isiOS7OrEarlier) {
+    if (isiOSVersionEarlierThan8) {
         // PROBLEM: under iOS 7, it seems that setting the proper insets in keyboardWillShow: is not
         // enough.  We were having trouble when adding images, where the keyboard would show but the
         // insets would be reset to {0, 0, 0, 0} between keyboardWillShow: and keyboardDidShow:
@@ -379,8 +380,10 @@ static NSInteger CaretPositionUnknow = -9999;
         //
         // - launch the WPiOS app under iOS 7.
         // - set a title
+        // - make sure the virtual keyboard is up
         // - add some text and on the same line add an image
         // - once the image is added tap once on the content field to make the keyboard come back up
+        //   (do this before the upload finishes).
         //
         // WORKAROUND: we just set the insets again in keyboardDidShow: for iOS 7
         //


### PR DESCRIPTION
Fixes [a problem when the keyboard is shown under iOS 7 after inserting images](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/301).

WPiOS branch `issue/301-cant-scroll` integrates this fix and makes it easy to test it.

/cc @SergioEstevao and @bummytime 