### PR TITLE
It's now possible to write multi-paragraph blockquotes.

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -122,22 +122,27 @@ ZSSEditor.focusFirstEditableField = function() {
     $('div[contenteditable=true]:first').focus();
 };
 
-
 ZSSEditor.formatNewLine = function(e) {
     
     var currentField = this.getFocusedField();
     
     if (currentField.isMultiline()) {
-        var currentNode = ZSSEditor.closerParentNodeWithName('blockquote');
+        var parentBlockQuoteNode = ZSSEditor.closerParentNodeWithName('blockquote');
         
-        if (!currentNode
-            && !ZSSEditor.isCommandEnabled('insertOrderedList')
-            && !ZSSEditor.isCommandEnabled('insertUnorderedList')) {
+        if (parentBlockQuoteNode) {
+            this.formatNewLineInsideBlockquote(e);
+        } else if (!ZSSEditor.isCommandEnabled('insertOrderedList')
+                   && !ZSSEditor.isCommandEnabled('insertUnorderedList')) {
             document.execCommand('formatBlock', false, 'p');
         }
     } else {
         e.preventDefault();
     }
+};
+
+ZSSEditor.formatNewLineInsideBlockquote = function(e) {
+    this.insertBreakTagAtCaretPosition();
+    e.preventDefault();
 };
 
 ZSSEditor.getField = function(fieldId) {
@@ -1479,6 +1484,24 @@ ZSSEditor.sendEnabledStyles = function(e) {
     }
 	
 	ZSSEditor.stylesCallback(items);
+};
+
+// MARK: - Commands: High Level Editing
+
+/**
+ *  @brief      Inserts a br tag at the caret position.
+ */
+ZSSEditor.insertBreakTagAtCaretPosition = function() {
+    // iOS IMPORTANT: we were adding <br> tags with range.insertNode() before using
+    // this method.  Unfortunately this was causing issues with the first <br> tag
+    // being completely ignored under iOS:
+    //
+    // https://bugs.webkit.org/show_bug.cgi?id=23474
+    //
+    // The following line seems to work fine under iOS, so please be careful if this
+    // needs to be changed for any reason.
+    //
+    document.execCommand("insertLineBreak");
 };
 
 // MARK: - Parent nodes & tags

--- a/Assets/editor.html
+++ b/Assets/editor.html
@@ -1091,7 +1091,7 @@ function style_html(html_source, options) {
             line-height: 28px;
         }
     }
-    
+
     </style>
   </head>
   <body>


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/499).

Going outside of the blockquote is impossible now, if all of the editor's text is in a single blockquote.  We'd probably need to think of a clever way to fix this - like for example allowing users to select text and remove the selection from the blockquote.

/cc @bummytime @SergioEstevao 