### PR TITLE
Local image url doesn't get replaced.

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -751,6 +751,7 @@ ZSSEditor.replaceLocalImageWithRemoteImage = function(imageNodeIdentifier, remot
         imageNode.attr('src', image.src);            
         var joinedArguments = ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments();
         ZSSEditor.callback("callback-input", joinedArguments);
+        this.markImageUploadDone(imageNodeIdentifier);
     }
     
     image.onerror = function () {
@@ -761,6 +762,7 @@ ZSSEditor.replaceLocalImageWithRemoteImage = function(imageNodeIdentifier, remot
         
         var joinedArguments = ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments();
         ZSSEditor.callback("callback-input", joinedArguments);
+        this.markImageUploadDone(imageNodeIdentifier);
     }
     
     image.src = remoteImageUrl;
@@ -777,10 +779,7 @@ ZSSEditor.setProgressOnImage = function(imageNodeIdentifier, progress) {
     if (imageNode.length == 0){
         return;
     }
-    if (progress >=1){
-        imageNode.removeClass("uploading");
-        imageNode.removeAttr("class");
-    } else {
+    if (progress < 1){
         imageNode.addClass("uploading");
     }
     
@@ -789,13 +788,31 @@ ZSSEditor.setProgressOnImage = function(imageNodeIdentifier, progress) {
           return;
     }
     imageProgressNode.attr("value",progress);
-    // if progress is finished remove all extra nodes.
-    if (progress >=1 &&
-        (imageNode.parent().attr("id") == this.getImageContainerIdentifier(imageNodeIdentifier)))
-    {
+};
+
+/**
+ *  @brief      Notifies that the image upload as finished and removed extra tags for upload
+ *
+ *  @param      imageNodeIdentifier     This is a unique ID provided by the caller.
+ */
+ZSSEditor.markImageUploadDone = function(imageNodeIdentifier) {
+    var imageNode = this.getImageNodeWithIdentifier(imageNodeIdentifier);
+    if (imageNode.length == 0){
+        return;
+    }
+    
+    // remove identifier attributed from image
+    imageNode.removeAttr('data-wpid');
+    
+    // remove uploading style
+    imageNode.removeClass("uploading");
+    imageNode.removeAttr("class");
+
+    // Remove all extra formatting nodes for progress
+    if (imageNode.parent().attr("id") == this.getImageContainerIdentifier(imageNodeIdentifier)) {
         imageNode.parent().replaceWith(imageNode);
     }
-};
+}
 
 /**
  *  @brief      Marks the image as failed to upload

--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -791,12 +791,12 @@ ZSSEditor.setProgressOnImage = function(imageNodeIdentifier, progress) {
 };
 
 /**
- *  @brief      Notifies that the image upload as finished and removed extra tags for upload
+ *  @brief      Notifies that the image upload as finished
  *
- *  @param      imageNodeIdentifier     This is a unique ID provided by the caller.
+ *  @param      imageNodeIdentifier     The unique image ID for the uploaded image
  */
 ZSSEditor.markImageUploadDone = function(imageNodeIdentifier) {
-
+    
     this.sendImageReplacedCallback(imageNodeIdentifier);
     
     var imageNode = this.getImageNodeWithIdentifier(imageNodeIdentifier);
@@ -810,20 +810,26 @@ ZSSEditor.markImageUploadDone = function(imageNodeIdentifier) {
     // remove uploading style
     imageNode.removeClass("uploading");
     imageNode.removeAttr("class");
-
+    
     // Remove all extra formatting nodes for progress
     if (imageNode.parent().attr("id") == this.getImageContainerIdentifier(imageNodeIdentifier)) {
         imageNode.parent().replaceWith(imageNode);
     }
-}
+};
 
+/**
+ *  @brief      Callbacks to native that the image upload as finished and the local url was replaced by the remote url
+ *
+ *  @param      imageNodeIdentifier     The unique image ID for the uploaded image
+ */
 ZSSEditor.sendImageReplacedCallback = function( imageNodeIdentifier ) {
     var arguments = ['id=' + encodeURIComponent( imageNodeIdentifier )];
     
     var joinedArguments = arguments.join( defaultCallbackSeparator );
     
     this.callback("callback-image-replaced", joinedArguments);
-}
+};
+
 /**
  *  @brief      Marks the image as failed to upload
  *

--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -738,12 +738,12 @@ ZSSEditor.getImageContainerNodeWithIdentifier = function(imageNodeIdentifier) {
 ZSSEditor.replaceLocalImageWithRemoteImage = function(imageNodeIdentifier, remoteImageUrl) {
     
     var imageNode = this.getImageNodeWithIdentifier(imageNodeIdentifier);
-    
+    this.markImageUploadDone(imageNodeIdentifier);
     if (imageNode.length == 0) {
         return;
     }
-    //when we decide to put the final url we can remove this from the node.
-    imageNode.removeAttr('data-wpid');
+    imageNode.attr('src', remoteImageUrl);
+    return;
     
     var image = new Image;
     

--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -736,22 +736,22 @@ ZSSEditor.getImageContainerNodeWithIdentifier = function(imageNodeIdentifier) {
  *  @param      remoteImageUrl          The URL of the remote image to display.
  */
 ZSSEditor.replaceLocalImageWithRemoteImage = function(imageNodeIdentifier, remoteImageUrl) {
-    
     var imageNode = this.getImageNodeWithIdentifier(imageNodeIdentifier);
-    this.markImageUploadDone(imageNodeIdentifier);
+    
     if (imageNode.length == 0) {
+        // even if the image is not present anymore we must do callback
+        this.markImageUploadDone(imageNodeIdentifier);
         return;
     }
-    imageNode.attr('src', remoteImageUrl);
-    return;
     
     var image = new Image;
     
     image.onload = function () {
-        imageNode.attr('src', image.src);            
+        imageNode.attr('src', image.src);
+        ZSSEditor.markImageUploadDone(imageNodeIdentifier);
         var joinedArguments = ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments();
         ZSSEditor.callback("callback-input", joinedArguments);
-        this.markImageUploadDone(imageNodeIdentifier);
+        
     }
     
     image.onerror = function () {
@@ -759,10 +759,10 @@ ZSSEditor.replaceLocalImageWithRemoteImage = function(imageNodeIdentifier, remot
         // blogs are currently failing to download images due to access privilege issues.
         //
         imageNode.attr('src', image.src);
-        
+        ZSSEditor.markImageUploadDone(imageNodeIdentifier);
         var joinedArguments = ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments();
         ZSSEditor.callback("callback-input", joinedArguments);
-        this.markImageUploadDone(imageNodeIdentifier);
+        
     }
     
     image.src = remoteImageUrl;
@@ -796,6 +796,9 @@ ZSSEditor.setProgressOnImage = function(imageNodeIdentifier, progress) {
  *  @param      imageNodeIdentifier     This is a unique ID provided by the caller.
  */
 ZSSEditor.markImageUploadDone = function(imageNodeIdentifier) {
+
+    this.sendImageReplacedCallback(imageNodeIdentifier);
+    
     var imageNode = this.getImageNodeWithIdentifier(imageNodeIdentifier);
     if (imageNode.length == 0){
         return;
@@ -814,6 +817,13 @@ ZSSEditor.markImageUploadDone = function(imageNodeIdentifier) {
     }
 }
 
+ZSSEditor.sendImageReplacedCallback = function( imageNodeIdentifier ) {
+    var arguments = ['id=' + encodeURIComponent( imageNodeIdentifier )];
+    
+    var joinedArguments = arguments.join( defaultCallbackSeparator );
+    
+    this.callback("callback-image-replaced", joinedArguments);
+}
 /**
  *  @brief      Marks the image as failed to upload
  *

--- a/Classes/WPEditorView.h
+++ b/Classes/WPEditorView.h
@@ -121,6 +121,17 @@
  */
 -        (void)editorView:(WPEditorView*)editorView
 stylesForCurrentSelection:(NSArray*)styles;
+
+/**
+ * @brief		Received when a image local url is replaced by the final remote url.
+ *
+ * @param		editorView	The editor view.
+ * @param		imageId		The id of image of the image that had the local url replaced by remote url.
+ *
+ */
+- (void)editorView:(WPEditorView*)editorView
+     imageReplaced:(NSString *)imageId;
+
 @end
 
 @interface WPEditorView : UIView

--- a/Classes/WPEditorViewController.h
+++ b/Classes/WPEditorViewController.h
@@ -61,6 +61,14 @@ WPEditorViewControllerMode;
                          url:(NSURL *)url
                    imageMeta:(WPImageMeta *)imageMeta;
 
+/**
+ *	@brief		Received when the local image url is replace by the final image in the editor.
+ *
+ *	@param		editorView	The editor view.
+ *	@param		imageId		The id of image of the image that was tapped.
+ */
+- (void)editorViewController:(WPEditorViewController*)editorViewController
+               imageReplaced:(NSString *)imageId;
 @end
 
 @class ZSSBarButtonItem;

--- a/Classes/WPEditorViewController.m
+++ b/Classes/WPEditorViewController.m
@@ -1635,7 +1635,7 @@ NSInteger const WPLinkAlertViewTag = 92;
 }
 
 - (void)editorView:(WPEditorView*)editorView
-       localImageReplaced:(NSString *)imageId
+       imageReplaced:(NSString *)imageId
 {
     if ([self.delegate respondsToSelector:@selector(editorViewController:imageReplaced:)]) {
         [self.delegate editorViewController:self imageReplaced:imageId];

--- a/Classes/WPEditorViewController.m
+++ b/Classes/WPEditorViewController.m
@@ -1634,6 +1634,15 @@ NSInteger const WPLinkAlertViewTag = 92;
     return YES;
 }
 
+- (void)editorView:(WPEditorView*)editorView
+       localImageReplaced:(NSString *)imageId
+{
+    if ([self.delegate respondsToSelector:@selector(editorViewController:imageReplaced:)]) {
+        [self.delegate editorViewController:self imageReplaced:imageId];
+    }
+}
+
+
 - (void)editorView:(WPEditorView*)editorView stylesForCurrentSelection:(NSArray*)styles
 {
     self.editorItemsEnabled = styles;

--- a/Example/EditorDemo/WPViewController.m
+++ b/Example/EditorDemo/WPViewController.m
@@ -106,6 +106,11 @@ typedef NS_ENUM(NSUInteger,  WPViewControllerActionSheet) {
     }
 }
 
+- (void)editorViewController:(WPEditorViewController *)editorViewController imageReplaced:(NSString *)imageId
+{
+    [self.imagesAdded removeObjectForKey:imageId];
+}
+
 - (void)showImageDetailsForImageMeta:(WPImageMeta *)imageMeta
 {
     WPImageMetaViewController *controller = [self.storyboard instantiateViewControllerWithIdentifier:@"WPImageMetaViewController"];
@@ -186,7 +191,6 @@ typedef NS_ENUM(NSUInteger,  WPViewControllerActionSheet) {
     
     if (progress.fractionCompleted >= 1){
         [self.editorView replaceLocalImageWithRemoteImage:[[NSURL fileURLWithPath:progress.userInfo[@"url"]] absoluteString] uniqueId:imageID];
-        [self.imagesAdded removeObjectForKey:imageID];
         [timer invalidate];
     }
 }


### PR DESCRIPTION
On some scenarios the local images weren't get replaced by the remote URL eve when the uploads look like they ended successful. This fix address this by only considering the upload complete when the replacement of the local image url for the remote url is done.

cc @bummytime, please review.